### PR TITLE
Update 2021-12-12-log4j-zero-day-mitigation-guide.md

### DIFF
--- a/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.md
+++ b/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.md
@@ -261,6 +261,12 @@ Or you can set this using the JVM arguments environment variable.
 
 `JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true`
 
+#### Does not fix Thread Context Map Substitutions
+
+Apparently this Option's mitigations do not prevent user controlled context that is passed via ThreadContextMap/ctx (and possibly other [PropertySubstitutions](https://logging.apache.org/log4j/2.x/manual/configuration.html#PropertySubstitution)). See demonstration here https://github.com/kmindi/log4shell-vulnerable-app 
+
+E.g. if your pattern layout contains something like `${ctx:apiversion}` the exploit might still work, at least a DNS lookup is performed.
+
 ### Option 3: JNDI patch
 It's possible to [modify the JNDI in place](https://news.ycombinator.com/item?id=29507263) to stop the attack at the language level.
 It can even be done while the server is running.  Please note this is a last resort, and should only be done if the above options aren't possible.


### PR DESCRIPTION
Adds information about Thread Context Map Property Substitutions that might still be vulnerable even with formatMsgNoLookups=true

**Please verify before just merging** I could just create a minimal example and minimal checks if 2.14.1 is really still vulnerable when using ctx. Great to hear if someone could confirm this.

I'm not sure about the other property substitutions and in general how popular these are, at elast for some commercial products ctx seems to be used.